### PR TITLE
The k8s project maintains release branches for the most recent minor releases

### DIFF
--- a/app-a/ch02/backup-restore-etcd/Vagrantfile
+++ b/app-a/ch02/backup-restore-etcd/Vagrantfile
@@ -2,6 +2,7 @@ BOX_IMAGE = "ubuntu/bionic64"
 WORKER_COUNT = 2
 POD_CIDR = "172.18.0.0/16"
 API_ADV_ADDRESS = "192.168.56.10"
+K8S_VERSION = "1.29.10-1.1"
 
 Vagrant.configure("2") do |config|
   config.vm.box = BOX_IMAGE
@@ -14,7 +15,7 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
       vb.cpus = 2
     end
-    node.vm.provision "shell", path: "common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
+    node.vm.provision "shell", path: "common.sh", args: "#{K8S_VERSION}"
     node.vm.provision "shell", path: "control-plane.sh", args: "#{POD_CIDR} #{API_ADV_ADDRESS}"
   end
 
@@ -27,7 +28,7 @@ Vagrant.configure("2") do |config|
         vb.memory = 1024
         vb.cpus = 2
       end
-      node.vm.provision "shell", path: "common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
+      node.vm.provision "shell", path: "common.sh", args: "#{K8S_VERSION}"
       node.vm.provision "shell", path: "worker.sh", args: "#{i}"
     end
   end

--- a/app-a/ch02/backup-restore-etcd/common.sh
+++ b/app-a/ch02/backup-restore-etcd/common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -z ${K8S_VERSION+x} ]; then
-  K8S_VERSION=1.26.1-1.1
+  K8S_VERSION=1.29.10-1.1
 fi
 
 # Install containerd container runtime

--- a/app-a/ch02/upgrade-version/Vagrantfile
+++ b/app-a/ch02/upgrade-version/Vagrantfile
@@ -2,6 +2,7 @@ BOX_IMAGE = "ubuntu/bionic64"
 WORKER_COUNT = 3
 POD_CIDR = "172.18.0.0/16"
 API_ADV_ADDRESS = "192.168.56.10"
+K8S_VERSION = "1.29.10-1.1"
 
 Vagrant.configure("2") do |config|
   config.vm.box = BOX_IMAGE
@@ -14,7 +15,7 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
       vb.cpus = 2
     end
-    node.vm.provision "shell", path: "common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
+    node.vm.provision "shell", path: "common.sh", args: "#{K8S_VERSION}"
     node.vm.provision "shell", path: "control-plane.sh", args: "#{POD_CIDR} #{API_ADV_ADDRESS}"
   end
 
@@ -27,7 +28,7 @@ Vagrant.configure("2") do |config|
         vb.memory = 1024
         vb.cpus = 2
       end
-      node.vm.provision "shell", path: "common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
+      node.vm.provision "shell", path: "common.sh", args: "#{K8S_VERSION}"
       node.vm.provision "shell", path: "worker.sh", args: "#{i}"
     end
   end

--- a/app-a/ch02/upgrade-version/common.sh
+++ b/app-a/ch02/upgrade-version/common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -z ${K8S_VERSION+x} ]; then
-  K8S_VERSION=1.26.1-1.1
+  K8S_VERSION=1.29.10-1.1
 fi
 
 # Install containerd container runtime


### PR DESCRIPTION
The Kubernetes project maintains release branches for the most recent three minor releases (1.31, 1.30, 1.29). 
There was an error while deploying VMs using Vagrant and it was related to kubeadm v1.26.1-1.1.
Hope it fixes the issue.