### PR TITLE
Service types in file names do not match actual service types

### DIFF
--- a/ch05/service/service-clusterip.yaml
+++ b/ch05/service/service-clusterip.yaml
@@ -3,9 +3,9 @@ kind: Service
 metadata:
   name: echoserver
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: echoserver
   ports:
-  - port: 5005
+  - port: 80
     targetPort: 8080

--- a/ch05/service/service-nodeport.yaml
+++ b/ch05/service/service-nodeport.yaml
@@ -3,9 +3,9 @@ kind: Service
 metadata:
   name: echoserver
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     app: echoserver
   ports:
-  - port: 80
+  - port: 5005
     targetPort: 8080


### PR DESCRIPTION
It seems the contents of two files are mixed up in the _ch05/service_ directory.

I would expect _service-clusterip.yaml_ to define a clusterip service but this file contains a nodeport service.

```
kubectl create -f service-clusterip.yaml
# service/echoserver created

kubectl get svc
# NAME         TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
# echoserver   NodePort    10.102.66.63   <none>        5005:30807/TCP   6s
```

Meanwhile, _service-nodeport.yaml_ defines a clusterip service.

```
kubectl create -f service-nodeport.yaml
# service/echoserver created

kubectl get svc
# NAME         TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
# echoserver   ClusterIP   10.97.149.45   <none>        80/TCP    5s
```

I swapped the contents of these two files so that file names can reflect the expected service types.