### PR TITLE
Unknown restartPolicy field

### DIFF
--- a/ch02/rbac/build-observer-pod.yaml
+++ b/ch02/rbac/build-observer-pod.yaml
@@ -11,4 +11,4 @@ spec:
     - while true; do date; sleep 10; done
     image: busybox
     name: build-observer
-restartPolicy: Never
+  restartPolicy: Never


### PR DESCRIPTION
The restartPolicy field of the _ch02/rbac/build-observer-pod.yaml_ file is not indented correctly therefore k8s returns a bad request error when I pass the file to kubectl.

```
kubectl create -f build-bot-serviceaccount.yaml
# serviceaccount/build-bot created

kubectl create -f build-observer-pod.yaml
# Error from server (BadRequest): error when creating "build-observer-pod.yaml": Pod in version "v1" cannot be handled as a Pod: strict decoding error: unknown field "restartPolicy"
```

I moved the restartPolicy to the pod.spec section so that k8s can process the pod definition.